### PR TITLE
adding base SonarQube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+# Required metadata
+sonar.projectKey=screenforce:tech-screening-service
+sonar.projectName=Screenforce Tech Screening Service
+sonar.projectVersion=2.1
+
+# Comma-separated paths to directories with sources
+sonar.sources=
+
+# Encoding of the source files
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
For code analysis in Jenkins
uses Screenforce for project name now instead of Caliber