### PR TITLE
YML convention edited for uniform white spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ numeric identifier (e.g. 1807). Stray branches will be deleted.
 The sledgehammer branch is the product owner's own branch, please do not 
 use this one. 
 
+##YML
+The convention for the YML files:
+- The document begins with the Spring declaration to begin with a uniform starting point, with no white space
+- All other main lines of the YML file begin with no white space 
+- From this intial main line, all following lines will get four additional white spaces
+- This process continues for as many additional lines as needed, with each getting an additional four white spaces
+- If any comments are added to the YML file then the # should be at the third white space
+- Any information for the comment should follow the line spacing listed above, so the # can be removed but the convention remains the same
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,9 +36,9 @@ info:
 eureka:
     client:
         service-url:
-            defaultZone: ${CALIBER_EUREKA_SERVER_URL}
+            defaultZone: ${SCREENFORCE_EUREKA_SERVER_URL}
     instance:
-   #  hostName: ${CALIBER_INSTANCE_HOSTNAME:localhost}
-   #  statusPageUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/info
-   #  healthCheckUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/health
+   #  hostName: ${SCREENFORCE_INSTANCE_HOSTNAME:localhost}
+   #  statusPageUrl: http://${SCREENFORCE_INSTANCE_HOSTNAME:localhost}:${server.port}/info
+   #  healthCheckUrl: http://${SCREENFORCE_INSTANCE_HOSTNAME:localhost}:${server.port}/health
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,44 @@
+spring:
+   #Configure Test H2 Database
+    datasource:
+        driver-class-name: org.h2.Driver
+        platform: h2
+        url: jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+        username: sa
+        password:
+    jpa:
+        hibernate:
+            ddl-auto: update
+server:
+    port: 8183
+
+security:
+    basic:
+        enabled: false
+
+management:
+    security:
+        enabled: false
+
+
+   #  endpoints:
+   #    web:
+   #      cors:
+   #        allow-credentials: true
+   #        allowed-headers: *
+   #        allowed-methods: *
+   #        allowed-origins: http://ec2-35-183-67-26.ca-central-1.compute.amazonaws.com:4200/
+   #        max-age: 1800s
+
+info:
+    component: Tech Screening Service
+
+eureka:
+    client:
+        service-url:
+            defaultZone: ${CALIBER_EUREKA_SERVER_URL}
+    instance:
+   #  hostName: ${CALIBER_INSTANCE_HOSTNAME:localhost}
+   #  statusPageUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/info
+   #  healthCheckUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/health
+

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,8 +1,10 @@
 spring:
-  application:
-    name: tech-screening-service
-  cloud:
-    config:
-      uri: ${SCREENFORCE_CONFIG_SERVER_URL}
-      fail-fast: true
- 
+    application:
+        name: tech-screening-service
+   #cloud:
+   # config:
+   #   uri: ${SCREENFORCE_CONFIG_SERVER_URL}
+   #   fail-fast: true
+
+
+      


### PR DESCRIPTION
Every YML file begins with the Spring line, to make them all uniform; every main line starts without whitespace; then every additional line beneath the main line gets 4 whitespaces per line, this process continues for however many additional lines a given main line may need; if any comments are added to the document, the # begins at the 3rd whitespace, and the whitespace following the hashtag is as it should be if the # was not there (i.e. 4 white spaces for every line after the first).